### PR TITLE
Reintroduce validation removed in video 378

### DIFF
--- a/src/main/java/guru/springframework/springrestclientexamples/controllers/UserController.java
+++ b/src/main/java/guru/springframework/springrestclientexamples/controllers/UserController.java
@@ -47,7 +47,22 @@ public class UserController {
                 apiService
                         .getUsers(serverWebExchange
                                 .getFormData()
-                                .map(data -> new Integer(data.getFirst("limit")))));
+                                .map(data -> {
+                                    String limitInput = data.getFirst("limit");
+                                    log.debug("Received Limit value: " + limitInput);
+                                    Integer limit;
+                                    try {
+                                        limit = new Integer(limitInput);
+                                    } catch (NumberFormatException e) {
+                                        limit = 0;
+                                    }
+                                    //default if null or zero
+                                    if (limit == 0) {
+                                        log.debug("Setting limit to default of 10");
+                                        limit = 10;
+                                    }
+                                    return limit;
+                                })));
 
         return "userlist";
     }


### PR DESCRIPTION
The video is called "Going Reactive with Spring WebClient" and as part of making the code reactive, the validation of null and zero limits has been removed.  While this is not strictly necessary to show how the reactive code works, I thought it was potentially confusing as it might imply that reactive code can't do validation as easily as non-reactive code.

In addition, I'm also catching NumberFormatException which wasn't done in the original and which would result in an unnecessary error when it could easily be averted with a default to a limit of 10.  This would happen, for example, if letters were used in the input instead of numbers. It could be argued that this should result in an exception. It would also happen if the limit were left blank.